### PR TITLE
Revert "Update tower-sessions requirement from 0.4.1 to 0.5.1 in /robotica-backend"

### DIFF
--- a/robotica-backend/Cargo.toml
+++ b/robotica-backend/Cargo.toml
@@ -42,7 +42,7 @@ url = "2.2.2"
 futures = "0.3.27"
 tower = "0.4.13"
 tower-http = { version = "0.4.0", features = ["fs", "trace"] }
-tower-sessions = { version = "0.5.1", features = ["moka-store"] }
+tower-sessions = { version = "0.4.1", features = ["moka-store"] }
 arc-swap = "1.4.0"
 hyper = "0.14.25"
 time = "0.3.30"


### PR DESCRIPTION
Reverts brianmay/robotica-rust#300

This doesn't update the lock file.