### PR TITLE
build: replace magic-nix-cache-action with cache-nix-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,24 @@ jobs:
     - uses: actions/checkout@v4
     - uses: nixbuild/nix-quick-install-action@v29
       with: {load_nixConfig: false}
-    - uses: DeterminateSystems/magic-nix-cache-action@v9
+    - name: Restore and cache Nix store
+      uses: nix-community/cache-nix-action@v5
+      with:
+        # restore and save a cache using this key
+        primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix') }}
+        # if there's no cache hit, restore a cache by this prefix
+        restore-prefixes-first-match: nix-${{ runner.os }}-
+        # collect garbage until Nix store size (in bytes) is at most this number
+        # before trying to save a new cache
+        gc-max-store-size-linux: 1073741824
+        # do purge caches
+        purge: true
+        # purge all versions of the cache
+        purge-prefixes: cache-${{ runner.os }}-
+        # created more than this number of seconds ago relative to the start of the `Post Restore` phase
+        purge-created: 0
+        # except the version with the `primary-key`, if it exists
+        purge-primary-key: never
     - run: nix flake check --impure
     - run: nix build '.#robotica-backend'
     - run: nix build '.#robotica-frontend'


### PR DESCRIPTION
magic-nix-cache-action is deprecated, see https://determinate.systems/posts/magic-nix-cache-free-tier-eol/